### PR TITLE
feat: iOS排序算法可视化应用更新

### DIFF
--- a/AllKindsOfSortForiOS/AllKindsOfSortForiOS.xcodeproj/project.pbxproj
+++ b/AllKindsOfSortForiOS/AllKindsOfSortForiOS.xcodeproj/project.pbxproj
@@ -123,6 +123,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -285,7 +286,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = ZeluLi.AllKindsOfSortForiOS;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -299,7 +300,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = ZeluLi.AllKindsOfSortForiOS;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
1. swift版本调到4，本地Xcode版本11.6
2. 优化业务逻辑控制 
    a. 原先流程：
        修改数值——点击键盘上的Done——点击排序；如果用户修改完数值后直接点击排序，键盘不会自动收起且由于程序中是直接写死的数值是200，体验上很僵硬。
    b. 现在流程：
        修改数值——点击排序。键盘自动收起，如果数值未修改则进行排序（此处会判断是否已经排序完成，若已排序完成则不再进行排序）；如果数值已修改则重置视图同时进行排序。
        修改数值——点击任意位置或点击Done，如果数值未修改则只是简单收起键盘；如果数值修改则重置视图。




